### PR TITLE
Release: v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## [0.4.0] - 2025-04-20
+
+### ✨ Added
+- Support regex matching in array fields via `ArrayRecordMatcher`.
+  - Example: `tags: /vip/` will now match any element inside an array.
+- Publicize `MatcherGenerator#update_initializer` to allow external CLI or test usage.
+
+### 🧹 Changed
+- Refactored `ValueConverter` to use direct method reference instead of dynamic caching logic.
+
+### 📝 Documentation
+- Improved matcher generator template documentation.
+  - Added usage examples and matcher tree explanation.
+  - Fixed `Mongory::Debugger` references to `Mongory.debugger`.
+
+### 💥 Breaking
+- Renamed gem from `mongory-rb` to `mongory`, affecting gemspec and file references.
+  - `mongory.gemspec` now used in place of `mongory-rb.gemspec`.
+
+# Changelog
+
 ## v0.3.0
 
 ### New Features

--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@
 
 source 'https://rubygems.org'
 
-# Specify your gem's dependencies in mongory-rb.gemspec
+# Specify your gem's dependencies in mongory.gemspec
 gemspec
 
 gem 'rake', '~> 13.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory (0.3.0)
+    mongory (0.4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    mongory-rb (0.3.0)
+    mongory (0.3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -50,7 +50,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  mongory-rb!
+  mongory!
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop (~> 1.28.2)

--- a/README.md
+++ b/README.md
@@ -44,12 +44,12 @@ This will generate `config/initializers/mongory.rb` and set up:
 
 Or install manually:
 ```bash
-gem install mongory-rb
+gem install mongory
 ```
 
 Or add to your Gemfile:
 ```ruby
-gem 'mongory-rb'
+gem 'mongory'
 ```
 
 ### Basic Usage

--- a/lib/generators/mongory/matcher/matcher_generator.rb
+++ b/lib/generators/mongory/matcher/matcher_generator.rb
@@ -28,10 +28,7 @@ module Mongory
 
         template 'matcher.rb.erb', "lib/mongory/matchers/#{file_name}_matcher.rb"
         template 'matcher_spec.rb.erb', "spec/mongory/matchers/#{file_name}_matcher_spec.rb"
-        update_initializer
       end
-
-      private
 
       # Updates or creates the Mongory initializer.
       #
@@ -45,7 +42,7 @@ module Mongory
         content = File.read(initializer_path)
         return if content.include?(inject_line)
 
-        required_file_lines = content.scan(/.+require\s+["'].*_matcher["'].+/)
+        required_file_lines = content.scan(/.*require\s+["'].*_matcher["'].*/)
         if required_file_lines.empty?
           inject_line = "\n#{inject_line}"
         else

--- a/lib/generators/mongory/matcher/templates/matcher.rb.erb
+++ b/lib/generators/mongory/matcher/templates/matcher.rb.erb
@@ -2,13 +2,77 @@
 
 # <%= @matcher_name %> implements the Mongo-style `<%= @mongo_operator %>` operator.
 #
-# @example
+# Instance Variables:
+# - @condition: The raw condition value passed to this matcher during initialization.
+#   This value is used for matching logic and should be validated in check_validity!.
+#
+# Condition Examples:
+#   # When query is: { field: { "<%= @mongo_operator %>" => your_condition } }
+#   # @condition will be: your_condition
+#
+#   # When query is: { field: { "<%= @mongo_operator %>" => { key: value } } }
+#   # @condition will be: { key: value }
+#
+#   # When query is: { field: { "<%= @mongo_operator %>" => [value1, value2] } }
+#   # @condition will be: [value1, value2]
+#
+# Matcher Tree Integration:
+# When this matcher is created as part of a matcher tree:
+# 1. It receives its @condition during initialization
+# 2. The @condition is validated via check_validity!
+# 3. The match method is called with normalized values
+# 4. The matcher can use normalize(record) to handle KEY_NOT_FOUND values
+#
+# This matcher typically serves as a leaf node in the matcher tree,
+# responsible for evaluating a single condition against a value.
+# It may be combined with other matchers through logical operators
+# like $and, $or, or $not to form complex conditions.
+#
+# Usage Examples:
+#   # Basic usage
 #   matcher = <%= @matcher_name %>.build(condition)
 #   matcher.match?(value) #=> true/false
+#
+#   # Usage in queries:
+#   # 1. Field-specific condition (MongoDB style)
+#   records.mongory.where(field: { "<%= @mongo_operator %>" => your_condition })
+#
+#   # 2. Field-specific condition (Ruby DSL style)
+#   records.mongory.where(:field.<%= @operator_name %> => your_condition)
+#
+#   # 3. Global condition (applies to all fields)
+#   records.mongory.where("<%= @mongo_operator %>" => your_condition)
+#
+# Implementation Notes:
+# 1. The match method should implement the specific operator logic
+# 2. Use normalize(subject) to handle KEY_NOT_FOUND values consistently
+# 3. The condition is available via @condition
+# 4. check_validity! should validate the format of @condition
+#
+# Interface Design:
+# This matcher provides two levels of matching interface:
+#
+# 1. Public Interface (match?):
+#    - Provides error handling
+#    - Ensures safe matching process
+#    - Suitable for external calls
+#    - Can be tracked by Mongory.debugger
+#    - Used for internal calls and debugging
+#
+# 2. Internal Interface (match):
+#    - Implements the actual matching logic
+#
+# Debugging Support:
+# The match method can be tracked by Mongory.debugger to:
+# - Visualize the matching process
+# - Diagnose matching issues
+# - Provide detailed debugging information
 #
 # @see Mongory::Matchers::AbstractMatcher
 class <%= @matcher_name %> < Mongory::Matchers::AbstractMatcher
   # Matches the subject against the condition.
+  # This is the internal interface that implements the actual matching logic.
+  # It can be tracked by Mongory.debugger for debugging purposes.
   #
   # @param subject [Object] the value to be tested
   # @return [Boolean] whether the value matches

--- a/lib/mongory-rb.rb
+++ b/lib/mongory-rb.rb
@@ -1,3 +1,0 @@
-# frozen_string_literal: true
-
-require_relative 'mongory'

--- a/lib/mongory/converters/value_converter.rb
+++ b/lib/mongory/converters/value_converter.rb
@@ -22,10 +22,8 @@ module Mongory
       # @return [void]
       def initialize
         super
-        d_convert = nil
         @fallback = Proc.new do
-          d_convert ||= DataConverter.instance.method(:convert)
-          d_convert.call(self)
+          Mongory.data_converter.convert(self)
         end
       end
 
@@ -37,10 +35,8 @@ module Mongory
 
         # - Hashes are interpreted as nested condition trees
         #   using ConditionConverter
-        c_convert = nil
         register(Hash) do
-          c_convert ||= ConditionConverter.instance.method(:convert)
-          c_convert.call(self)
+          Mongory.condition_converter.convert(self)
         end
 
         register(String, :itself)

--- a/lib/mongory/matchers/array_record_matcher.rb
+++ b/lib/mongory/matchers/array_record_matcher.rb
@@ -24,6 +24,7 @@ module Mongory
     # @see Mongory::Matchers::InMatcher
     # @see Mongory::Matchers::LiteralMatcher
     class ArrayRecordMatcher < AbstractMultiMatcher
+      enable_unwrap!
       # Builds an array of matchers to evaluate the given condition against an array record.
       #
       # This method returns multiple matchers that will be evaluated using `:any?` logic:
@@ -34,7 +35,7 @@ module Mongory
       # @return [Array<Mongory::Matchers::AbstractMatcher>] an array of matcher instances
       define_instance_cache_method(:matchers) do
         result = []
-        result << EqMatcher.build(@condition)
+        result << EqMatcher.build(@condition) if @condition.is_a?(Array)
         result << if @condition.is_a?(Hash)
                     HashConditionMatcher.build(parsed_condition)
                   else

--- a/lib/mongory/matchers/array_record_matcher.rb
+++ b/lib/mongory/matchers/array_record_matcher.rb
@@ -36,8 +36,11 @@ module Mongory
       define_instance_cache_method(:matchers) do
         result = []
         result << EqMatcher.build(@condition) if @condition.is_a?(Array)
-        result << if @condition.is_a?(Hash)
+        result << case @condition
+                  when Hash
                     HashConditionMatcher.build(parsed_condition)
+                  when Regexp
+                    ElemMatchMatcher.build('$regex' => @condition)
                   else
                     ElemMatchMatcher.build('$eq' => @condition)
                   end

--- a/lib/mongory/query_builder.rb
+++ b/lib/mongory/query_builder.rb
@@ -35,6 +35,7 @@ module Mongory
     def each
       return to_enum(:each) unless block_given?
 
+      @matcher.prepare_query
       @records.each do |record|
         yield record if @matcher.match?(record)
       end

--- a/lib/mongory/query_matcher.rb
+++ b/lib/mongory/query_matcher.rb
@@ -48,5 +48,19 @@ module Mongory
     def render_tree
       super
     end
+
+    # Prepares the query for execution by ensuring all necessary matchers are initialized.
+    # This is called before query execution to avoid premature matcher tree construction.
+    #
+    # @return [void]
+    alias_method :prepare_query, :check_validity!
+
+    # Overrides the parent class's check_validity! to prevent premature matcher tree construction.
+    # This matcher does not require validation, so this is a no-op.
+    #
+    # @return [void]
+    def check_validity!
+      # No-op for this matcher
+    end
   end
 end

--- a/lib/mongory/version.rb
+++ b/lib/mongory/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Mongory
-  VERSION = '0.3.0'
+  VERSION = '0.4.0'
 end

--- a/mongory.gemspec
+++ b/mongory.gemspec
@@ -3,7 +3,7 @@
 require_relative 'lib/mongory/version'
 
 Gem::Specification.new do |spec|
-  spec.name = 'mongory-rb'
+  spec.name = 'mongory'
   spec.version = Mongory::VERSION
   spec.authors = ['koten0224']
   spec.email = ['koten0224@gmail.com']

--- a/spec/query_matcher_spec.rb
+++ b/spec/query_matcher_spec.rb
@@ -14,7 +14,7 @@ end
 converter.register(FakeBsonId, :to_s)
 
 RSpec.describe Mongory::QueryMatcher, type: :model do
-  subject { described_class.new(condition) }
+  subject { described_class.new(condition).tap(&:prepare_query) }
 
   context '#match?' do
     context 'basic condition' do


### PR DESCRIPTION
# Release: v0.4.0

Released on **2025-04-20**

---

## 🚀 Highlights

- **Regex support inside array fields**
  - Now you can query arrays using regex directly. Example:
    ```ruby
    Mongory.where(tags: /vip/)
    ```
    This will match any record where the `tags` array includes a value matching `/vip/`.

- **Matcher generator improvements**
  - `update_initializer` method is now public — enabling better CLI tooling and test control.
  - Template documentation now includes condition examples, matcher structure, and debugging usage.

- **Refined internals**
  - Cleaner `ValueConverter` fallback using method reference instead of dynamic method caching.

- **Package renamed**
  - The gem is now named `mongory`, instead of `mongory-rb`.

---

## 📦 Breaking Change

- 💥 `mongory-rb.gemspec` has been renamed to `mongory.gemspec`.
- You may need to update your `Gemfile` and `require` paths accordingly.

---

## 📚 Documentation

- Improved inline documentation in matcher templates.
- Fixed incorrect debugger references in generated files.

---

## 📁 Files Changed

- `lib/mongory/matchers/array_record_matcher.rb`
- `lib/generators/mongory/matcher/templates/matcher.rb.erb`
- `lib/generators/mongory/matcher/matcher_generator.rb`
- `lib/mongory/converters/value_converter.rb`
- `Gemfile`, `gemspec` updated due to rename

---

Thanks for using **Mongory** ❤️
