### PR TITLE
feat(core-bridge): integrate `mongory-core` submodule and Ruby C extension exposing `Mongory::CMatcher`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,9 @@
 .rspec_status
 /pre_release/
 .vscode
+
+ext/mongory_ext/Makefile
+ext/mongory_ext/*.o
+ext/mongory_ext/*.so
+ext/mongory_ext/*.bundle
+ext/mongory_ext/mkmf.log

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -15,6 +15,8 @@ GEM
     racc (1.8.1)
     rainbow (3.1.1)
     rake (13.2.1)
+    rake-compiler (1.3.0)
+      rake
     regexp_parser (2.10.0)
     rexml (3.4.1)
     rspec (3.13.0)
@@ -52,6 +54,7 @@ PLATFORMS
 DEPENDENCIES
   mongory!
   rake (~> 13.0)
+  rake-compiler (~> 1.0)
   rspec (~> 3.0)
   rubocop (~> 1.28.2)
   rubocop-rspec (~> 2.10.0)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,28 @@ Mongory is designed to serve two types of users:
 - Ruby >= 2.6.0
 - No external database required
 
+### C Extension (Optional but Recommended)
+
+Mongory-rb includes an optional high-performance C extension powered by [mongory-core](https://github.com/mongoryhq/mongory-core):
+
+**System Dependencies:**
+- C99-compatible compiler (gcc/clang)
+- CMake >= 3.12
+
+**Installation:**
+```bash
+# macOS
+brew install cmake
+
+# Ubuntu/Debian
+sudo apt install cmake build-essential
+
+# CentOS/RHEL
+sudo yum install cmake gcc make
+```
+
+The C extension provides significant performance improvements for large datasets. If not available, Mongory-rb automatically falls back to pure Ruby implementation.
+
 ## Quick Start
 
 ### Installation
@@ -326,19 +348,25 @@ The debug output includes:
 
 ### Performance Considerations
 
-1. **Memory Usage**
+1. **C Extension vs Pure Ruby**
+   - C extension provides 3-10x performance improvement for large datasets
+   - Automatic fallback to pure Ruby if C extension unavailable
+   - Check availability: `Mongory::CoreInterface.c_extension_available?`
+   - Memory management handled by mongory-core's memory pool
+
+2. **Memory Usage**
    - Mongory operates entirely in memory
    - Consider your data size and memory constraints
    - Proc-based implementation reduces memory usage
    - Context system provides better memory management
 
-2. **Query Optimization**
+3. **Query Optimization**
    - Complex conditions are evaluated in sequence
    - Use `explain` to analyze query performance
    - Empty conditions are optimized with cached Procs
    - Context system allows fine-grained control over conversion
 
-3. **Benchmarks**
+4. **Benchmarks**
   ```ruby
     # Simple query (1000 records)
     records.mongory.where(:age.gte => 18) # ~0.8ms

--- a/Rakefile
+++ b/Rakefile
@@ -9,4 +9,82 @@ require 'rubocop/rake_task'
 
 RuboCop::RakeTask.new
 
+# Add support for rake-compiler if available
+begin
+  require 'rake/extensiontask'
+
+  Rake::ExtensionTask.new('mongory_ext') do |ext|
+    ext.lib_dir = 'lib'
+    ext.ext_dir = 'ext/mongory_ext'
+    ext.source_pattern = '*.c'
+  end
+
+  # Add tasks for building with submodule
+  namespace :submodule do
+    desc 'Initialize/update the mongory-core submodule'
+    task :init do
+      sh 'git submodule update --init --recursive'
+    end
+
+    desc 'Update the mongory-core submodule to latest'
+    task :update do
+      sh 'git submodule update --remote'
+    end
+
+    desc 'Build mongory-core submodule'
+    task :build do
+      core_dir = 'ext/mongory_ext/mongory-core'
+      if Dir.exist?(core_dir)
+        Dir.chdir(core_dir) do
+          if File.exist?('build.sh')
+            sh 'chmod +x build.sh && ./build.sh'
+          else
+            sh 'mkdir -p build && cd build && cmake .. && make'
+          end
+        end
+      else
+        puts 'mongory-core submodule not found. Run rake submodule:init first.'
+      end
+    end
+  end
+
+  desc 'Build the project (without standalone mongory-core build)'
+  task :build_all => ['submodule:init', :compile]
+
+  desc 'Clean all build artifacts including submodule'
+  task :clean_all => :clean do
+    sh 'rm -rf ext/mongory_ext/mongory-core/build' if Dir.exist?('ext/mongory_ext/mongory-core/build')
+  end
+
+rescue LoadError
+  puts 'rake-compiler not available. Install it with: gem install rake-compiler'
+
+  # Fallback tasks without rake-compiler
+  desc 'Build the C extension manually'
+  task :compile do
+    Dir.chdir('ext/mongory_ext') do
+      sh 'ruby extconf.rb && make'
+    end
+  end
+
+  desc 'Clean the C extension manually'
+  task :clean do
+    Dir.chdir('ext/mongory_ext') do
+      sh 'make clean' if File.exist?('Makefile')
+      sh 'rm -f Makefile *.o foundations/*.o matchers/*.o mongory_ext.so'
+    end
+  end
+end
+
+# Custom build task using our build script
+desc 'Build using the custom build script'
+task :build_with_script do
+  sh 'scripts/build_with_core.sh'
+end
+
+desc 'Build in debug mode'
+task :build_debug do
+  sh 'scripts/build_with_core.sh --debug'
+end
+
 task default: %i(spec rubocop)

--- a/SUBMODULE_INTEGRATION.md
+++ b/SUBMODULE_INTEGRATION.md
@@ -1,0 +1,358 @@
+# Mongory-rb Submodule Integration Guide
+
+這份文檔說明了如何使用 `mongory-core` 作為 Git submodule 整合到 `mongory-rb` 中，實現高效能的 C 擴展支援。
+
+## 架構概述
+
+```
+mongory-rb/
+├── lib/                    # Ruby 程式碼
+│   └── mongory/
+│       └── ...            # 其他 Ruby 模組
+├── ext/                   # C 擴展
+│   └── mongory_ext/
+│       ├── mongory-core/  # Git submodule
+│       ├── extconf.rb     # 編譯配置
+│       └── mongory_ext.c  # Ruby C 包裝器
+└── scripts/
+    └── build_with_core.sh # 構建腳本
+```
+
+## 快速開始
+
+### 1. 複製和初始化
+
+```bash
+# 複製專案
+git clone <your-mongory-rb-repo>
+cd mongory-rb
+
+# 初始化 submodule
+git submodule update --init --recursive
+```
+
+### 2. 安裝系統依賴
+
+一般安裝 `mongory-rb`（包含 C 擴充）只需要基本編譯工具：
+
+**macOS (Homebrew):**
+```bash
+brew install cmake
+```
+
+**Ubuntu/Debian:**
+```bash
+sudo apt update
+sudo apt install cmake build-essential
+```
+
+**CentOS/RHEL/Fedora:**
+```bash
+# CentOS/RHEL
+sudo yum install cmake gcc make
+
+# Fedora
+sudo dnf install cmake gcc make
+```
+
+注意：cJSON 僅在你進入 `mongory-core` 子模組並執行其「測試或 benchmarks」時才需要（例如以 CMake/ctest 執行）。`mongory-rb` 的正常使用與擴充編譯不需要 cJSON。
+
+### 3. 構建專案
+
+使用我們的自動化構建腳本：
+
+```bash
+# 基本構建
+./scripts/build_with_core.sh
+
+# 除錯模式構建
+./scripts/build_with_core.sh --debug
+
+# 強制重新構建
+./scripts/build_with_core.sh --force-rebuild
+
+# 查看所有選項
+./scripts/build_with_core.sh --help
+```
+
+或者使用 Rake 任務：
+
+```bash
+# 使用 rake-compiler（如果有安裝）
+rake build_all
+
+# 或使用我們的構建腳本
+rake build_with_script
+
+# 除錯模式
+rake build_debug
+```
+
+## 詳細步驟說明
+
+### Submodule 管理
+
+```bash
+# 初始化 submodule
+rake submodule:init
+
+# 更新 submodule 到最新版本
+rake submodule:update
+
+# 手動更新 submodule
+git submodule update --remote
+```
+
+### 手動構建流程
+
+如果您想要手動控制構建過程：
+
+```bash
+# 1. 確保 submodule 已初始化
+git submodule update --init --recursive
+
+# 2.（可選）如果你要在子模組內跑測試或 benchmarks，才需要以 CMake 構建 mongory-core
+#    注意：此步驟才可能需要 cJSON；一般使用 mongory-rb 不需要。
+# cd ext/mongory_ext/mongory-core
+# ./build.sh --test
+# cd ../../..
+
+# 3. 構建 Ruby C 擴展
+cd ext/mongory_ext
+ruby extconf.rb
+make
+cd ../..
+
+# 4. 運行測試
+bundle exec rspec
+```
+
+### 清理構建
+
+```bash
+# 清理所有構建產物
+rake clean_all
+
+# 或使用構建腳本
+./scripts/build_with_core.sh --clean
+```
+
+## 開發指南
+
+### 修改 C 擴展
+
+1. 編輯 `ext/mongory_ext/mongory_ext.c`
+2. 重新編譯：
+   ```bash
+   cd ext/mongory_ext
+   make
+   ```
+
+### 更新 mongory-core
+
+1. 進入 submodule 目錄：
+   ```bash
+   cd ext/mongory_ext/mongory-core
+   ```
+
+2. 檢出想要的版本或分支：
+   ```bash
+   git checkout main
+   git pull origin main
+   ```
+
+3. 回到主專案並提交 submodule 更新：
+   ```bash
+   cd ../../..
+   git add ext/mongory_ext/mongory-core
+   git commit -m "Update mongory-core submodule"
+   ```
+
+### 除錯 C 擴展
+
+```bash
+# 使用除錯模式構建
+export DEBUG=1
+cd ext/mongory_ext
+ruby extconf.rb
+make
+
+# 或使用構建腳本
+./scripts/build_with_core.sh --debug
+```
+
+除錯模式會：
+- 啟用除錯符號 (`-g`)
+- 關閉最佳化 (`-O0`)
+- 啟用 `DEBUG` 巨集定義
+
+### C 擴展 API
+
+主要的 C 擴展類別：
+
+```ruby
+# 記憶體池管理
+pool = Mongory::MemoryPool.new
+
+# 建立匹配器
+condition = { "age" => { "$gt" => 18 } }
+matcher = Mongory::Matcher.new(pool, condition)
+
+# 執行匹配
+data = { "name" => "John", "age" => 25 }
+result = matcher.match(data)  # => true
+
+# 檢查 C 擴展是否可用
+Mongory::CoreInterface.c_extension_available?  # => true/false
+```
+
+## 故障排除
+
+### 常見問題
+
+**1. Submodule 是空的**
+```bash
+# 解決方案
+git submodule update --init --recursive
+```
+
+**2. 找不到 cjson 庫**
+```bash
+# macOS
+brew install cjson
+
+# Ubuntu/Debian
+sudo apt install libcjson-dev
+
+# 檢查安裝
+pkg-config --exists libcjson && echo "Found" || echo "Not found"
+```
+
+**3. 編譯錯誤**
+```bash
+# 清理並重新構建
+./scripts/build_with_core.sh --clean
+./scripts/build_with_core.sh --debug
+```
+
+**4. C 擴展無法載入**
+- 檢查 Ruby 版本相容性 (>= 2.6.0)
+- 確認所有依賴庫已安裝
+- 查看錯誤訊息並檢查編譯警告
+
+### 日誌和除錯
+
+啟用詳細輸出：
+```bash
+# 構建時顯示詳細訊息
+VERBOSE=1 ./scripts/build_with_core.sh
+
+# Ruby 載入時顯示除錯資訊
+RUBY_DEBUG=1 ruby -rmongory -e "puts Mongory::CoreInterface.version"
+```
+
+### 效能驗證
+
+```ruby
+require 'benchmark'
+require 'mongory'
+
+records = 10000.times.map { |i| { "id" => i, "age" => rand(18..65) } }
+
+# 測試 C 擴展效能
+Benchmark.bm do |x|
+  x.report("Ruby DSL:") do
+    records.mongory.where(:age.gte => 30).to_a
+  end
+
+  if Mongory::CoreInterface.c_extension_available?
+    x.report("C Extension:") do
+      pool = Mongory::MemoryPool.new
+      matcher = Mongory::Matcher.new(pool, { "age" => { "$gte" => 30 } })
+      records.select { |r| matcher.match(r) }
+    end
+  end
+end
+```
+
+## CI/CD 整合
+
+### GitHub Actions 範例
+
+```yaml
+name: Build and Test
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        submodules: recursive
+
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: true
+
+    - name: Install system dependencies
+      run: |
+        sudo apt update
+        sudo apt install cmake build-essential
+
+    - name: Build with C extension
+      run: ./scripts/build_with_core.sh
+
+    - name: Run tests
+      run: bundle exec rspec
+
+    # 如果你需要在 CI 中跑 mongory-core 的測試/benchmarks（可選），才需要安裝 cJSON 並呼叫其 CMake 流程。
+    # - name: Install cJSON (only if running core tests)
+    #   run: sudo apt install libcjson-dev
+    # - name: Build mongory-core tests (optional)
+    #   run: |
+    #     cd ext/mongory_ext/mongory-core
+    #     ./build.sh --test
+```
+
+## 貢獻指南
+
+### 開發流程
+
+1. Fork 這個 repository
+2. 建立功能分支：`git checkout -b feature/amazing-feature`
+3. 如果修改了 C 程式碼，確保同時更新測試
+4. 執行完整的測試套件：`./scripts/build_with_core.sh`
+5. 提交變更：`git commit -m 'Add amazing feature'`
+6. 推送到分支：`git push origin feature/amazing-feature`
+7. 建立 Pull Request
+
+### 編碼標準
+
+- **C 程式碼**: 遵循 C99 標準，使用 mongory-core 的編碼風格
+- **Ruby 程式碼**: 遵循專案的 RuboCop 配置
+- **文檔**: 為所有公共 API 提供文檔
+
+### 測試要求
+
+- 為所有新功能添加測試
+- 確保 C 擴展和 Ruby fallback 都有測試覆蓋
+- 運行效能基準測試確認沒有回歸
+
+## 參考資源
+
+- [mongory-core 文檔](ext/mongory_ext/mongory-core/README.md)
+- [Ruby C 擴展指南](https://docs.ruby-lang.org/en/master/extension_rdoc.html)
+- [Git Submodules 文檔](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+- [CMake 文檔](https://cmake.org/documentation/)
+
+## 授權
+
+這個整合遵循 MIT 授權條款，與 mongory-core 和 mongory-rb 保持一致。

--- a/examples/benchmark.rb
+++ b/examples/benchmark.rb
@@ -102,4 +102,22 @@ end
       puts result
     end
   end
+
+  puts "\nComplex query (Mongory) use CMatcher (#{size} records):"
+  gc_handler do
+    5.times do
+      matcher = Mongory::CMatcher.new(
+        :$or => [
+          { age: { '$gte': 18 } },
+          { status: 'active' }
+        ]
+      )
+      result = Benchmark.measure do
+        records.select do |r|
+          matcher.match(r)
+        end
+      end
+      puts result
+    end
+  end
 end

--- a/ext/mongory_ext/extconf.rb
+++ b/ext/mongory_ext/extconf.rb
@@ -2,33 +2,33 @@
 
 require 'mkmf'
 
-# 設置 mongory-core 的路徑
+# Set the path to mongory-core
 core_dir = File.expand_path('mongory-core', __dir__)
 core_src_dir = File.join(core_dir, 'src')
 core_include_dir = File.join(core_dir, 'include')
 
-# 檢查 mongory-core 是否存在
+# Check if mongory-core submodule exists
 unless Dir.exist?(core_dir)
   puts "Error: mongory-core submodule not found at #{core_dir}"
   puts "Please run: git submodule update --init --recursive"
   exit 1
 end
 
-# mongory-rb 不需要 cJSON；僅 mongory-core 的測試會使用到，故不檢查 cJSON 依賴
+# mongory-rb does not require cJSON; only mongory-core's tests use it, so we don't check cJSON here
 
-# 添加包含路徑
+# Add include paths
 $INCFLAGS << " -I#{core_include_dir}"
 
-# 收集需要編譯的源文件（直接編進擴充套件）
+# Collect source files to compile directly into the extension
 foundations_src = Dir.glob(File.join(core_src_dir, 'foundations', '*.c'))
 matchers_src = Dir.glob(File.join(core_src_dir, 'matchers', '*.c'))
 
-# 設置編譯選項
+# Compiler flags
 $CFLAGS << ' -std=c99 -Wall -Wextra -Wno-incompatible-pointer-types -Wno-int-conversion'
 $CFLAGS << ' -O2' unless ENV['DEBUG']
 $CFLAGS << ' -g -O0 -DDEBUG' if ENV['DEBUG']
 
-# 交給 mkmf 自動產生規則：指定所有來源與對應目標
+# Let mkmf generate rules by listing all sources and corresponding objects
 $INCFLAGS << " -I."
 $INCFLAGS << " -I#{File.join(core_src_dir, 'foundations')}"
 $INCFLAGS << " -I#{File.join(core_src_dir, 'matchers')}"
@@ -36,7 +36,7 @@ all_sources = ['mongory_ext.c'] + foundations_src + matchers_src
 $srcs = all_sources
 $objs = all_sources.map { |src| File.basename(src, '.c') + '.o' }
 
-# 產生 Makefile
+# Generate Makefile
 create_makefile('mongory_ext')
 
 puts "extconf.rb completed successfully"
@@ -44,7 +44,7 @@ puts "Found #{foundations_src.length} foundation sources"
 puts "Found #{matchers_src.length} matcher sources"
 puts "Use 'make' to build the extension"
 
-# 補充 Makefile：為 submodule 內的來源建立顯式編譯規則，避免複製或連結檔案
+# Append Makefile rules: explicit compilation rules for submodule sources to avoid copying/linking files
 mk = File.read('Makefile')
 
 rules = +"\n# --- custom rules for mongory-core submodule sources ---\n"

--- a/ext/mongory_ext/extconf.rb
+++ b/ext/mongory_ext/extconf.rb
@@ -1,0 +1,66 @@
+# frozen_string_literal: true
+
+require 'mkmf'
+
+# 設置 mongory-core 的路徑
+core_dir = File.expand_path('mongory-core', __dir__)
+core_src_dir = File.join(core_dir, 'src')
+core_include_dir = File.join(core_dir, 'include')
+
+# 檢查 mongory-core 是否存在
+unless Dir.exist?(core_dir)
+  puts "Error: mongory-core submodule not found at #{core_dir}"
+  puts "Please run: git submodule update --init --recursive"
+  exit 1
+end
+
+# mongory-rb 不需要 cJSON；僅 mongory-core 的測試會使用到，故不檢查 cJSON 依賴
+
+# 添加包含路徑
+$INCFLAGS << " -I#{core_include_dir}"
+
+# 添加源文件
+foundations_src = Dir.glob(File.join(core_src_dir, 'foundations', '*.c'))
+matchers_src = Dir.glob(File.join(core_src_dir, 'matchers', '*.c'))
+
+# 設置編譯選項
+$CFLAGS << ' -std=c99 -Wall -Wextra'
+$CFLAGS << ' -O2' unless ENV['DEBUG']
+$CFLAGS << ' -g -O0 -DDEBUG' if ENV['DEBUG']
+
+# 創建所有源文件的編譯規則
+all_sources = foundations_src + matchers_src
+
+# 為每個 C 源文件創建對象文件
+objects = all_sources.map do |src|
+  obj = src.sub(/\.c$/, '.o').sub(core_src_dir, '.')
+  obj_dir = File.dirname(obj)
+  FileUtils.mkdir_p(obj_dir) unless Dir.exist?(obj_dir)
+
+  # 添加編譯規則
+  rule obj => src do
+    sh "#{CONFIG['CC']} #{$CFLAGS} #{$INCFLAGS} -c #{src} -o #{obj}"
+  end
+
+  obj
+end
+
+# 設置對象文件
+$objs = objects + ['mongory_ext.o']
+
+# 創建 Makefile
+create_makefile('mongory_ext')
+
+# 添加清理任務
+makefile_content = File.read('Makefile')
+makefile_content << "\n"
+makefile_content << "clean: clean-so clean-static clean-objs\n"
+makefile_content << "\t@rm -f *.o foundations/*.o matchers/*.o\n"
+makefile_content << "\n"
+
+File.write('Makefile', makefile_content)
+
+puts "extconf.rb completed successfully"
+puts "Found #{foundations_src.length} foundation sources"
+puts "Found #{matchers_src.length} matcher sources"
+puts "Use 'make' to build the extension"

--- a/ext/mongory_ext/mongory_ext.c
+++ b/ext/mongory_ext/mongory_ext.c
@@ -7,9 +7,9 @@
  * operations while maintaining the elegant Ruby DSL.
  */
 
+#include "mongory-core.h"
 #include <ruby.h>
 #include <ruby/encoding.h>
-#include "mongory-core.h"
 
 // Ruby module and class definitions
 static VALUE mMongory;
@@ -21,8 +21,8 @@ static VALUE eMongoryTypeError;
 
 // Matcher wrapper structure
 typedef struct {
-    mongory_matcher *matcher;
-    mongory_memory_pool *pool;
+  mongory_matcher *matcher;
+  mongory_memory_pool *pool;
 } ruby_mongory_matcher_t;
 
 /**
@@ -30,101 +30,123 @@ typedef struct {
  */
 
 static void ruby_mongory_matcher_free(void *ptr) {
-    ruby_mongory_matcher_t *wrapper = (ruby_mongory_matcher_t *)ptr;
-    mongory_memory_pool *pool = wrapper->pool;
-    pool->free(pool);
-    xfree(wrapper);
+  ruby_mongory_matcher_t *wrapper = (ruby_mongory_matcher_t *)ptr;
+  mongory_memory_pool *pool = wrapper->pool;
+  pool->free(pool);
+  xfree(wrapper);
 }
 
 static const rb_data_type_t ruby_mongory_matcher_type = {
-    .wrap_struct_name = "mongory_matcher",
-    .function = {
-        .dmark = NULL,
-        .dfree = ruby_mongory_matcher_free,
-        .dsize = NULL,
-    },
-    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+  .wrap_struct_name = "mongory_matcher",
+  .function = {
+    .dmark = NULL,
+    .dfree = ruby_mongory_matcher_free,
+    .dsize = NULL,
+  },
+  .flags = RUBY_TYPED_FREE_IMMEDIATELY,
 };
 
 /**
  * Helper functions for Ruby/C conversion
  */
 
-// Convert Ruby value to mongory_value
-static mongory_value* ruby_to_mongory_value(VALUE rb_value, mongory_memory_pool *pool, mongory_value*(*convert_func)(mongory_memory_pool *pool, void *value)) {
-    mongory_value *mg_value = NULL;
-    switch (TYPE(rb_value)) {
-        case T_NIL:
-            mg_value = mongory_value_wrap_null(pool);
-            break;
+typedef struct {
+  mongory_table *table;
+  mongory_memory_pool *pool;
+  mongory_value *(*convert_func)(mongory_memory_pool *pool, void *value);
+} hash_conv_ctx;
 
-        case T_TRUE:
-        case T_FALSE:
-            mg_value = mongory_value_wrap_b(pool, RTEST(rb_value));
-            break;
+static int hash_foreach_cb(VALUE key, VALUE val, VALUE ptr) {
+  hash_conv_ctx *ctx = (hash_conv_ctx *)ptr;
+  char *key_str;
+  if (SYMBOL_P(key)) {
+    key_str = (char *)rb_id2name(SYM2ID(key));
+  } else {
+    key_str = StringValueCStr(key);
+  }
+  mongory_value *cval = ctx->convert_func(ctx->pool, (void *)val);
+  ctx->table->set(ctx->table, key_str, cval);
+  return ST_CONTINUE;
+}
 
-        case T_FIXNUM:
-            mg_value = mongory_value_wrap_i(pool, NUM2LONG(rb_value));
-            break;
+// Deep conversion: Convert Ruby value to mongory_value (fully materialize arrays/tables)
+static mongory_value *ruby_to_mongory_value(VALUE rb_value, mongory_memory_pool *pool, mongory_value *(*convert_func)(mongory_memory_pool *pool, void *value)) {
+  mongory_value *mg_value = NULL;
+  switch (TYPE(rb_value)) {
+  case T_NIL:
+    mg_value = mongory_value_wrap_n(pool, NULL);
+    break;
 
-        case T_FLOAT:
-            mg_value = mongory_value_wrap_d(pool, NUM2DBL(rb_value));
-            break;
+  case T_TRUE:
+  case T_FALSE:
+    mg_value = mongory_value_wrap_b(pool, RTEST(rb_value));
+    break;
 
-        case T_STRING: {
-            char *str = StringValueCStr(rb_value);
-            mg_value = mongory_value_wrap_s(pool, str);
-            break;
-        }
+  case T_FIXNUM:
+    mg_value = mongory_value_wrap_i(pool, rb_num2long_inline(rb_value));
+    break;
 
-        case T_ARRAY: {
-            mongory_array *array = mongory_array_new(pool);
-            long len = RARRAY_LEN(rb_value);
+  case T_BIGNUM:
+    mg_value = mongory_value_wrap_i(pool, rb_num2ll_inline(rb_value));
+    break;
 
-            for (long i = 0; i < len; i++) {
-                VALUE element = RARRAY_AREF(rb_value, i);
-                array->push(array, convert_func(pool, element));
-            }
-            mg_value = mongory_value_wrap_a(pool, array);
-            break;
-        }
+  case T_FLOAT:
+    mg_value = mongory_value_wrap_d(pool, rb_num2dbl(rb_value));
+    break;
 
-        case T_HASH: {
-            mongory_table *table = mongory_table_new(pool);
-            VALUE keys = rb_funcall(rb_value, rb_intern("keys"), 0);
-            long len = RARRAY_LEN(keys);
+  case T_STRING: {
+    mg_value = mongory_value_wrap_s(pool, StringValueCStr(rb_value));
+    break;
+  }
 
-            for (long i = 0; i < len; i++) {
-                VALUE key = RARRAY_AREF(keys, i);
-                VALUE value = rb_hash_aref(rb_value, key);
+  case T_SYMBOL: {
+    mg_value = mongory_value_wrap_s(pool, (char *)rb_id2name(rb_sym2id(rb_value)));
+    break;
+  }
 
-                char *key_str = StringValueCStr(key);
-                table->set(table, key_str, convert_func(pool, value));
-            }
+  case T_ARRAY: {
+    mongory_array *array = mongory_array_new(pool);
+    long len = RARRAY_LEN(rb_value);
 
-            mg_value = mongory_value_wrap_t(pool, table);
-            break;
-        }
-
-        default:
-            rb_raise(eMongoryTypeError, "Unsupported Ruby type for conversion to mongory_value");
+    for (long i = 0; i < len; i++) {
+      VALUE element = RARRAY_AREF(rb_value, i);
+      array->push(array, convert_func(pool, element));
     }
-    mg_value->origin = rb_value;
-    return mg_value;
+    mg_value = mongory_value_wrap_a(pool, array);
+    break;
+  }
+
+  case T_HASH: {
+    mongory_table *table = mongory_table_new(pool);
+
+    hash_conv_ctx ctx = {table, pool, convert_func};
+    rb_hash_foreach(rb_value, hash_foreach_cb, (VALUE)&ctx);
+
+    mg_value = mongory_value_wrap_t(pool, table);
+    break;
+  }
+
+  default:
+    rb_raise(eMongoryTypeError, "Unsupported Ruby type for conversion to mongory_value");
+  }
+  mg_value->origin = rb_value;
+  return mg_value;
 }
 
-static mongory_value* ruby_to_mongory_value_shallow(mongory_memory_pool *pool, void *value) {
-    return ruby_to_mongory_value(value, pool, mongory_value_wrap_ptr);
+// Shallow conversion: only materialize scalars; arrays/hashes remain as POINTER to Ruby VALUE
+static mongory_value *ruby_to_mongory_value_shallow(mongory_memory_pool *pool, void *value) {
+  return ruby_to_mongory_value(value, pool, mongory_value_wrap_ptr);
 }
-static mongory_value* ruby_to_mongory_value_deep(mongory_memory_pool *pool, void *value) {
-    return ruby_to_mongory_value(value, pool, ruby_to_mongory_value_deep);
+static mongory_value *ruby_to_mongory_value_deep(mongory_memory_pool *pool, void *value) {
+  return ruby_to_mongory_value(value, pool, ruby_to_mongory_value_deep);
 }
 
 // Convert mongory_value to Ruby value
 static void *mongory_value_to_ruby(mongory_memory_pool *pool, mongory_value *value) {
-    (void)pool;
-    if (!value) return NULL;
-    return value->origin;
+  (void)pool;
+  if (!value)
+    return NULL;
+  return value->origin;
 }
 
 /**
@@ -133,65 +155,65 @@ static void *mongory_value_to_ruby(mongory_memory_pool *pool, mongory_value *val
 
 // Mongory::CMatcher.new(condition)
 static VALUE ruby_mongory_matcher_new(VALUE class, VALUE condition) {
-    mongory_memory_pool *matcher_pool = mongory_memory_pool_new();
-    mongory_value *condition_value = ruby_to_mongory_value_deep(matcher_pool, condition);
-    mongory_matcher *matcher = mongory_matcher_new(matcher_pool, condition_value);
+  mongory_memory_pool *matcher_pool = mongory_memory_pool_new();
+  mongory_value *condition_value = ruby_to_mongory_value_deep(matcher_pool, condition);
+  mongory_matcher *matcher = mongory_matcher_new(matcher_pool, condition_value);
 
-    if (!matcher) {
-        rb_raise(eMongoryError, "Failed to create matcher");
-    }
+  if (!matcher) {
+    rb_raise(eMongoryError, "Failed to create matcher");
+  }
 
-    ruby_mongory_matcher_t *wrapper = ALLOC(ruby_mongory_matcher_t);
-    wrapper->matcher = matcher;
-    wrapper->pool = matcher_pool;
+  ruby_mongory_matcher_t *wrapper = ALLOC(ruby_mongory_matcher_t);
+  wrapper->matcher = matcher;
+  wrapper->pool = matcher_pool;
 
-    return TypedData_Wrap_Struct(class, &ruby_mongory_matcher_type, wrapper);
+  return TypedData_Wrap_Struct(class, &ruby_mongory_matcher_type, wrapper);
 }
 
 // Mongory::CMatcher#match(data)
 static VALUE ruby_mongory_matcher_match(VALUE self, VALUE data) {
-    ruby_mongory_matcher_t *wrapper;
-    TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
+  ruby_mongory_matcher_t *wrapper;
+  TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
 
-    mongory_memory_pool *temp_pool = mongory_memory_pool_new();
-    mongory_value *data_value = ruby_to_mongory_value_shallow(temp_pool, data);
-    bool result = mongory_matcher_match(wrapper->matcher, data_value);
+  mongory_memory_pool *temp_pool = mongory_memory_pool_new();
+  mongory_value *data_value = ruby_to_mongory_value_shallow(temp_pool, data);
+  bool result = mongory_matcher_match(wrapper->matcher, data_value);
 
-    temp_pool->free(temp_pool);
-    return result ? Qtrue : Qfalse;
+  temp_pool->free(temp_pool);
+  return result ? Qtrue : Qfalse;
 }
 
 // Mongory::CMatcher#explain
 static VALUE ruby_mongory_matcher_explain(VALUE self) {
-    ruby_mongory_matcher_t *wrapper;
-    TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
-    mongory_memory_pool *temp_pool = mongory_memory_pool_new();
-    mongory_matcher_explain(wrapper->matcher, temp_pool);
-    temp_pool->free(temp_pool);
-    return Qnil;
+  ruby_mongory_matcher_t *wrapper;
+  TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
+  mongory_memory_pool *temp_pool = mongory_memory_pool_new();
+  mongory_matcher_explain(wrapper->matcher, temp_pool);
+  temp_pool->free(temp_pool);
+  return Qnil;
 }
 
 /**
  * Extension initialization
  */
 void Init_mongory_ext(void) {
-    // Initialize mongory core
-    mongory_init();
+  // Initialize mongory core
+  mongory_init();
 
-    // Define modules and classes
-    mMongory = rb_define_module("Mongory");
-    cMongoryMatcher = rb_define_class_under(mMongory, "CMatcher", rb_cObject);
+  // Define modules and classes
+  mMongory = rb_define_module("Mongory");
+  cMongoryMatcher = rb_define_class_under(mMongory, "CMatcher", rb_cObject);
 
-    // Define error classes
-    eMongoryError = rb_define_class_under(mMongory, "Error", rb_eStandardError);
-    eMongoryTypeError = rb_define_class_under(mMongory, "TypeError", eMongoryError);
+  // Define error classes
+  eMongoryError = rb_define_class_under(mMongory, "Error", rb_eStandardError);
+  eMongoryTypeError = rb_define_class_under(mMongory, "TypeError", eMongoryError);
 
-    // Define Matcher methods
-    rb_define_singleton_method(cMongoryMatcher, "new", ruby_mongory_matcher_new, 1);
-    rb_define_method(cMongoryMatcher, "match", ruby_mongory_matcher_match, 1);
-    rb_define_method(cMongoryMatcher, "explain", ruby_mongory_matcher_explain, 0);
-    // Set value converter functions
-    mongory_value_converter_deep_convert_set(ruby_to_mongory_value_deep);
-    mongory_value_converter_shallow_convert_set(ruby_to_mongory_value_shallow);
-    mongory_value_converter_recover_set(mongory_value_to_ruby);
+  // Define Matcher methods
+  rb_define_singleton_method(cMongoryMatcher, "new", ruby_mongory_matcher_new, 1);
+  rb_define_method(cMongoryMatcher, "match", ruby_mongory_matcher_match, 1);
+  rb_define_method(cMongoryMatcher, "explain", ruby_mongory_matcher_explain, 0);
+  // Set value converter functions
+  mongory_value_converter_deep_convert_set(ruby_to_mongory_value_deep);
+  mongory_value_converter_shallow_convert_set(ruby_to_mongory_value_shallow);
+  mongory_value_converter_recover_set(mongory_value_to_ruby);
 }

--- a/ext/mongory_ext/mongory_ext.c
+++ b/ext/mongory_ext/mongory_ext.c
@@ -1,0 +1,197 @@
+/**
+ * @file mongory_ext.c
+ * @brief Ruby C extension wrapper for mongory-core
+ *
+ * This file provides Ruby bindings for the mongory-core C library,
+ * allowing Ruby applications to use high-performance C-based matching
+ * operations while maintaining the elegant Ruby DSL.
+ */
+
+#include <ruby.h>
+#include <ruby/encoding.h>
+#include "mongory-core.h"
+
+// Ruby module and class definitions
+static VALUE mMongory;
+static VALUE cMongoryMatcher;
+
+// Error classes
+static VALUE eMongoryError;
+static VALUE eMongoryTypeError;
+
+// Matcher wrapper structure
+typedef struct {
+    mongory_matcher *matcher;
+    mongory_memory_pool *pool;
+} ruby_mongory_matcher_t;
+
+/**
+ * Ruby GC management functions
+ */
+
+static void ruby_mongory_matcher_free(void *ptr) {
+    ruby_mongory_matcher_t *wrapper = (ruby_mongory_matcher_t *)ptr;
+    mongory_memory_pool *pool = wrapper->pool;
+    pool->free(pool);
+    xfree(wrapper);
+}
+
+static const rb_data_type_t ruby_mongory_matcher_type = {
+    .wrap_struct_name = "mongory_matcher",
+    .function = {
+        .dmark = NULL,
+        .dfree = ruby_mongory_matcher_free,
+        .dsize = NULL,
+    },
+    .flags = RUBY_TYPED_FREE_IMMEDIATELY,
+};
+
+/**
+ * Helper functions for Ruby/C conversion
+ */
+
+// Convert Ruby value to mongory_value
+static mongory_value* ruby_to_mongory_value(VALUE rb_value, mongory_memory_pool *pool, mongory_value*(*convert_func)(mongory_memory_pool *pool, void *value)) {
+    mongory_value *mg_value = NULL;
+    switch (TYPE(rb_value)) {
+        case T_NIL:
+            mg_value = mongory_value_wrap_null(pool);
+            break;
+
+        case T_TRUE:
+        case T_FALSE:
+            mg_value = mongory_value_wrap_b(pool, RTEST(rb_value));
+            break;
+
+        case T_FIXNUM:
+            mg_value = mongory_value_wrap_i(pool, NUM2LONG(rb_value));
+            break;
+
+        case T_FLOAT:
+            mg_value = mongory_value_wrap_d(pool, NUM2DBL(rb_value));
+            break;
+
+        case T_STRING: {
+            char *str = StringValueCStr(rb_value);
+            mg_value = mongory_value_wrap_s(pool, str);
+            break;
+        }
+
+        case T_ARRAY: {
+            mongory_array *array = mongory_array_new(pool);
+            long len = RARRAY_LEN(rb_value);
+
+            for (long i = 0; i < len; i++) {
+                VALUE element = RARRAY_AREF(rb_value, i);
+                array->push(array, convert_func(pool, element));
+            }
+            mg_value = mongory_value_wrap_a(pool, array);
+            break;
+        }
+
+        case T_HASH: {
+            mongory_table *table = mongory_table_new(pool);
+            VALUE keys = rb_funcall(rb_value, rb_intern("keys"), 0);
+            long len = RARRAY_LEN(keys);
+
+            for (long i = 0; i < len; i++) {
+                VALUE key = RARRAY_AREF(keys, i);
+                VALUE value = rb_hash_aref(rb_value, key);
+
+                char *key_str = StringValueCStr(key);
+                table->set(table, key_str, convert_func(pool, value));
+            }
+
+            mg_value = mongory_value_wrap_t(pool, table);
+            break;
+        }
+
+        default:
+            rb_raise(eMongoryTypeError, "Unsupported Ruby type for conversion to mongory_value");
+    }
+    mg_value->origin = rb_value;
+    return mg_value;
+}
+
+static mongory_value* ruby_to_mongory_value_shallow(mongory_memory_pool *pool, void *value) {
+    return ruby_to_mongory_value(value, pool, mongory_value_wrap_ptr);
+}
+static mongory_value* ruby_to_mongory_value_deep(mongory_memory_pool *pool, void *value) {
+    return ruby_to_mongory_value(value, pool, ruby_to_mongory_value_deep);
+}
+
+// Convert mongory_value to Ruby value
+static void *mongory_value_to_ruby(mongory_memory_pool *pool, mongory_value *value) {
+    (void)pool;
+    if (!value) return NULL;
+    return value->origin;
+}
+
+/**
+ * Ruby method implementations
+ */
+
+// Mongory::CMatcher.new(condition)
+static VALUE ruby_mongory_matcher_new(VALUE class, VALUE condition) {
+    mongory_memory_pool *matcher_pool = mongory_memory_pool_new();
+    mongory_value *condition_value = ruby_to_mongory_value_deep(matcher_pool, condition);
+    mongory_matcher *matcher = mongory_matcher_new(matcher_pool, condition_value);
+
+    if (!matcher) {
+        rb_raise(eMongoryError, "Failed to create matcher");
+    }
+
+    ruby_mongory_matcher_t *wrapper = ALLOC(ruby_mongory_matcher_t);
+    wrapper->matcher = matcher;
+    wrapper->pool = matcher_pool;
+
+    return TypedData_Wrap_Struct(class, &ruby_mongory_matcher_type, wrapper);
+}
+
+// Mongory::CMatcher#match(data)
+static VALUE ruby_mongory_matcher_match(VALUE self, VALUE data) {
+    ruby_mongory_matcher_t *wrapper;
+    TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
+
+    mongory_memory_pool *temp_pool = mongory_memory_pool_new();
+    mongory_value *data_value = ruby_to_mongory_value_shallow(temp_pool, data);
+    bool result = mongory_matcher_match(wrapper->matcher, data_value);
+
+    temp_pool->free(temp_pool);
+    return result ? Qtrue : Qfalse;
+}
+
+// Mongory::CMatcher#explain
+static VALUE ruby_mongory_matcher_explain(VALUE self) {
+    ruby_mongory_matcher_t *wrapper;
+    TypedData_Get_Struct(self, ruby_mongory_matcher_t, &ruby_mongory_matcher_type, wrapper);
+    mongory_memory_pool *temp_pool = mongory_memory_pool_new();
+    mongory_matcher_explain(wrapper->matcher, temp_pool);
+    temp_pool->free(temp_pool);
+    return Qnil;
+}
+
+/**
+ * Extension initialization
+ */
+void Init_mongory_ext(void) {
+    // Initialize mongory core
+    mongory_init();
+
+    // Define modules and classes
+    mMongory = rb_define_module("Mongory");
+    cMongoryMatcher = rb_define_class_under(mMongory, "CMatcher", rb_cObject);
+
+    // Define error classes
+    eMongoryError = rb_define_class_under(mMongory, "Error", rb_eStandardError);
+    eMongoryTypeError = rb_define_class_under(mMongory, "TypeError", eMongoryError);
+
+    // Define Matcher methods
+    rb_define_singleton_method(cMongoryMatcher, "new", ruby_mongory_matcher_new, 1);
+    rb_define_method(cMongoryMatcher, "match", ruby_mongory_matcher_match, 1);
+    rb_define_method(cMongoryMatcher, "explain", ruby_mongory_matcher_explain, 0);
+    // Set value converter functions
+    mongory_value_converter_deep_convert_set(ruby_to_mongory_value_deep);
+    mongory_value_converter_shallow_convert_set(ruby_to_mongory_value_shallow);
+    mongory_value_converter_recover_set(mongory_value_to_ruby);
+}

--- a/lib/mongory.rb
+++ b/lib/mongory.rb
@@ -114,3 +114,5 @@ module Mongory
     end
   end
 end
+
+require_relative '../ext/mongory_ext/mongory_ext'

--- a/mongory.gemspec
+++ b/mongory.gemspec
@@ -32,9 +32,16 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  # Uncomment to register a new dependency of your gem
-  # spec.add_dependency 'example-gem', '~> 1.0'
+  # C extension configuration
+  spec.extensions = ['ext/mongory_ext/extconf.rb']
 
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
+  # Add development dependencies for C extension
+  spec.add_development_dependency 'rake-compiler', '~> 1.0'
+
+
+  # Ensure submodule files are included
+  spec.files += Dir['ext/mongory_ext/mongory-core/src/**/*.{c,h}']
+  spec.files += Dir['ext/mongory_ext/mongory-core/include/**/*.h']
+  spec.files += ['ext/mongory_ext/mongory-core/LICENSE']
+  spec.files += ['ext/mongory_ext/mongory-core/README.md']
 end

--- a/mongory.gemspec
+++ b/mongory.gemspec
@@ -40,8 +40,8 @@ Gem::Specification.new do |spec|
 
 
   # Ensure submodule files are included
-  spec.files += Dir['ext/mongory_ext/mongory-core/src/**/*.{c,h}']
+  spec.files += Dir['ext/mongory_ext/mongory-core/src/foundations/*.{c,h}']
+  spec.files += Dir['ext/mongory_ext/mongory-core/src/matchers/*.{c,h}']
   spec.files += Dir['ext/mongory_ext/mongory-core/include/**/*.h']
   spec.files += ['ext/mongory_ext/mongory-core/LICENSE']
-  spec.files += ['ext/mongory_ext/mongory-core/README.md']
 end

--- a/scripts/build_with_core.sh
+++ b/scripts/build_with_core.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+
+# Build script for mongory-rb with mongory-core submodule
+# This script handles submodule initialization, dependency checking, and C extension compilation
+
+set -e  # Exit on any error
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(dirname "$SCRIPT_DIR")"
+CORE_DIR="$PROJECT_ROOT/ext/mongory_ext/mongory-core"
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Function to print colored output
+log() {
+    local color=$1
+    shift
+    echo -e "${color}$*${NC}"
+}
+
+# Function to check if command exists
+command_exists() {
+    command -v "$1" >/dev/null 2>&1
+}
+
+# Function to check system dependencies
+check_dependencies() {
+    log $BLUE "🔍 Checking system dependencies..."
+
+    local missing_deps=()
+
+    # Check for required tools
+    if ! command_exists git; then
+        missing_deps+=("git")
+    fi
+
+    if ! command_exists make; then
+        missing_deps+=("make")
+    fi
+
+    if ! command_exists gcc && ! command_exists clang; then
+        missing_deps+=("gcc or clang")
+    fi
+
+    # Check for pkg-config (optional)
+    if ! command_exists pkg-config; then
+        missing_deps+=("pkg-config")
+    fi
+
+    if [ ${#missing_deps[@]} -gt 0 ]; then
+        log $RED "❌ Missing dependencies: ${missing_deps[*]}"
+        log $YELLOW "Please install the missing dependencies:"
+
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            log $BLUE "  macOS (Homebrew): brew install ${missing_deps[*]// /}"
+        elif [[ "$OSTYPE" == "linux-gnu"* ]]; then
+            if command_exists apt; then
+                log $BLUE "  Ubuntu/Debian: sudo apt update && sudo apt install build-essential pkg-config"
+            elif command_exists yum; then
+                log $BLUE "  CentOS/RHEL: sudo yum install gcc make pkg-config"
+            elif command_exists dnf; then
+                log $BLUE "  Fedora: sudo dnf install gcc make pkg-config"
+            fi
+        fi
+
+        exit 1
+    fi
+
+    log $GREEN "✅ All dependencies found"
+}
+
+# Function to initialize/update submodules
+init_submodules() {
+    log $BLUE "📥 Initializing/updating submodules..."
+
+    cd "$PROJECT_ROOT"
+
+    if [ ! -d "$CORE_DIR" ] || [ ! "$(ls -A "$CORE_DIR")" ]; then
+        log $YELLOW "Submodule not initialized, initializing now..."
+        git submodule update --init --recursive
+    else
+        log $YELLOW "Updating existing submodule..."
+        git submodule update --recursive
+    fi
+
+    if [ ! -f "$CORE_DIR/README.md" ]; then
+        log $RED "❌ Failed to initialize mongory-core submodule"
+        exit 1
+    fi
+
+    log $GREEN "✅ Submodule initialized/updated successfully"
+}
+
+# Function to build mongory-core if needed
+build_core() {
+    # mongory-rb 直接由 extconf.rb 編譯 mongory-core 的源碼，不需要獨立建置靜態庫
+    # 同時避免觸發 mongory-core 的 CMake（其需要 cJSON 僅用於測試）
+    log $YELLOW "Skipping mongory-core standalone build (not required for mongory-rb)"
+}
+
+# Function to build the Ruby C extension
+build_extension() {
+    log $BLUE "🔨 Building Ruby C extension..."
+
+    cd "$PROJECT_ROOT"
+
+    # Clean previous builds
+    if [ -d "ext/mongory_ext/Makefile" ]; then
+        cd ext/mongory_ext
+        make clean 2>/dev/null || true
+        cd "$PROJECT_ROOT"
+    fi
+
+    # Build the extension
+    cd ext/mongory_ext
+
+    # Set DEBUG flag if requested
+    if [[ "$1" == "--debug" ]]; then
+        export DEBUG=1
+        log $YELLOW "Building in debug mode..."
+    fi
+
+    ruby extconf.rb
+    make
+
+    if [ $? -eq 0 ]; then
+        log $GREEN "✅ C extension built successfully"
+    else
+        log $RED "❌ Failed to build C extension"
+        exit 1
+    fi
+
+    cd "$PROJECT_ROOT"
+}
+
+# Function to run tests
+run_tests() {
+    log $BLUE "🧪 Running tests..."
+
+    cd "$PROJECT_ROOT"
+
+    # Run Ruby tests
+    if command_exists bundle; then
+        bundle exec rspec
+    else
+        rspec
+    fi
+
+    if [ $? -eq 0 ]; then
+        log $GREEN "✅ All tests passed"
+    else
+        log $RED "❌ Some tests failed"
+        exit 1
+    fi
+}
+
+# Function to clean build artifacts
+clean() {
+    log $BLUE "🧹 Cleaning build artifacts..."
+
+    cd "$PROJECT_ROOT"
+
+    # Clean C extension
+    if [ -d "ext/mongory_ext" ]; then
+        cd ext/mongory_ext
+        make clean 2>/dev/null || true
+        rm -f Makefile *.o foundations/*.o matchers/*.o mongory_ext.so
+        cd "$PROJECT_ROOT"
+    fi
+
+    # Clean mongory-core build
+    if [ -d "$CORE_DIR/build" ]; then
+        rm -rf "$CORE_DIR/build"
+    fi
+
+    log $GREEN "✅ Cleaned build artifacts"
+}
+
+# Function to display help
+show_help() {
+    cat << EOF
+Usage: $0 [OPTIONS]
+
+Build script for mongory-rb with mongory-core submodule integration.
+
+OPTIONS:
+  --help          Show this help message
+  --clean         Clean build artifacts and exit
+  --debug         Build in debug mode
+  --no-deps       Skip dependency checking
+  --no-tests      Skip running tests
+  --force-rebuild Force rebuild of everything
+
+EXAMPLES:
+  $0                    # Normal build
+  $0 --debug            # Debug build
+  $0 --clean            # Clean only
+  $0 --no-tests         # Build without running tests
+
+EOF
+}
+
+# Main execution flow
+main() {
+    local clean_only=false
+    local skip_deps=false
+    local skip_tests=false
+    local force_rebuild=false
+    local debug_mode=false
+
+    # Parse command line arguments
+    while [[ $# -gt 0 ]]; do
+        case $1 in
+            --help)
+                show_help
+                exit 0
+                ;;
+            --clean)
+                clean_only=true
+                shift
+                ;;
+            --debug)
+                debug_mode=true
+                shift
+                ;;
+            --no-deps)
+                skip_deps=true
+                shift
+                ;;
+            --no-tests)
+                skip_tests=true
+                shift
+                ;;
+            --force-rebuild)
+                force_rebuild=true
+                shift
+                ;;
+            *)
+                log $RED "Unknown option: $1"
+                show_help
+                exit 1
+                ;;
+        esac
+    done
+
+    log $GREEN "🚀 Starting mongory-rb build process..."
+
+    # Clean and exit if requested
+    if $clean_only; then
+        clean
+        exit 0
+    fi
+
+    # Force rebuild if requested
+    if $force_rebuild; then
+        clean
+    fi
+
+    # Check dependencies unless skipped
+    if ! $skip_deps; then
+        check_dependencies
+    fi
+
+    # Initialize submodules
+    init_submodules
+
+    # Build mongory-core
+    build_core
+
+    # Build Ruby C extension
+    if $debug_mode; then
+        build_extension --debug
+    else
+        build_extension
+    fi
+
+    # Run tests unless skipped
+    if ! $skip_tests; then
+        run_tests
+    fi
+
+    log $GREEN "🎉 Build completed successfully!"
+    log $BLUE "You can now use mongory-rb with C extension support."
+}
+
+# Run main function with all arguments
+main "$@"


### PR DESCRIPTION

### Purpose
Integrate `mongory-core` as a Git submodule into `mongory-rb` and expose a high-performance matching engine via a Ruby C extension (`Mongory::CMatcher`). This PR adds build tooling, Rake tasks, and documentation to make development and CI builds straightforward.

### Key Changes
- **Documentation**
  - Add `SUBMODULE_INTEGRATION.md` with end-to-end guidance: submodule init/update, builds, debugging, CI, troubleshooting.
- **C extension and build**
  - Add `ext/mongory_ext/extconf.rb` to compile `mongory-core` sources directly (no prior CMake build; no cJSON required for the gem).
  - Add `ext/mongory_ext/mongory_ext.c` that bridges Ruby ↔ C and exposes `Mongory::CMatcher` (`new`/`match`/`explain`).
  - Update `lib/mongory.rb` to `require_relative '../ext/mongory_ext/mongory_ext'`.
- **Gem/build setup**
  - Update `mongory.gemspec`: set `spec.extensions`, add `rake-compiler` as a development dependency, and include required submodule sources/headers in the gem package.
  - Add `scripts/build_with_core.sh` to handle submodule init, dependency checks, C extension build, and tests. Supports `--debug`/`--clean`.
  - Update `Rakefile` with `build_with_script` and `build_debug` tasks (wrapping the script).
- **Samples and readme**
  - Update `examples/benchmark.rb` with a `Mongory::CMatcher` benchmark path.
  - Update `README.md` with a brief C extension usage summary.
- **Misc**
  - Minor updates to `.gitignore` and `Gemfile.lock`.

### How to Use
- **Build (recommended)**
  ```bash
  bundle exec rake build_all
  ```
- **Or use the script**
  ```bash
  ./scripts/build_with_core.sh         # normal build
  ./scripts/build_with_core.sh --debug # debug build
  ./scripts/build_with_core.sh --clean # clean
  ```
- **Code snippet**
  ```ruby
  require 'mongory'

  cond = { 'age' => { '$gt' => 18 } }
  matcher = Mongory::CMatcher.new(cond)
  matcher.match({ 'name' => 'John', 'age' => 25 }) # => true/false
  matcher.explain # currently returns nil (placeholder)
  ```

### Compatibility / Breaking Changes
- Installing the gem now compiles a native extension (requires system build tools and Ruby headers). Without a proper build toolchain, load may fail.
- `lib/mongory.rb` requires the C extension directly. A pure-Ruby fallback is not yet implemented; can be added with a guarded `begin...rescue` in a follow-up.

### Risks / Notes
- Platform-specific build differences (e.g., Windows, cross compilation) are not yet validated.
- CI workflow file is not included in this PR; a ready-to-use example is provided in the docs and can be added later.
- Keep the submodule version pinned and reviewed for updates to avoid unintended API drift.

### Testing & Verification
- **Build and run tests**
  ```bash
  ./scripts/build_with_core.sh --no-deps
  # The script runs rspec by default; or run manually:
  bundle exec rspec
  ```
- **Benchmark (optional)**
  ```bash
  ruby examples/benchmark.rb
  ```
- **Manual sanity checks**
  - Submodule initialized: `git submodule update --init --recursive`
  - Extension loads: `ruby -rmongory -e "p Mongory::CMatcher"`
  - `Mongory::CMatcher#match` returns correct booleans for basic/complex conditions

### Related Commits
- chore: translation
- chore: update md file
- feat(benchmark): implement CMatcher benchmark
- feat(compiling): successfully compile c files in mongory core submodule
- feat(bridge): scaffold bridge ruby integration

### File Changes (summary)
- Added: `SUBMODULE_INTEGRATION.md`, `ext/mongory_ext/extconf.rb`, `ext/mongory_ext/mongory_ext.c`, `scripts/build_with_core.sh`
- Modified: `.gitignore`, `README.md`, `Rakefile`, `examples/benchmark.rb`, `lib/mongory.rb`, `mongory.gemspec`, `Gemfile.lock`