### PR TITLE
Feature/performance improvement

### DIFF
--- a/SUBMODULE_INTEGRATION.md
+++ b/SUBMODULE_INTEGRATION.md
@@ -293,7 +293,7 @@ jobs:
 
 ### Development workflow
 
-1. Fork 這個 repository
+1. Fork this repository
 2. Create a feature branch: `git checkout -b feature/amazing-feature`
 3. If you modify C code, make sure to update tests
 4. Run the full test suite: `./scripts/build_with_core.sh`
@@ -315,10 +315,10 @@ jobs:
 
 ## References
 
-- [mongory-core 文檔](https://github.com/mongoryhq/mongory-core)
-- [Ruby C 擴展指南](https://docs.ruby-lang.org/en/master/extension_rdoc.html)
-- [Git Submodules 文檔](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
-- [CMake 文檔](https://cmake.org/documentation/)
+- [mongory-core doc](https://github.com/mongoryhq/mongory-core)
+- [Ruby C extension doc](https://docs.ruby-lang.org/en/master/extension_rdoc.html)
+- [Git Submodules doc](https://git-scm.com/book/en/v2/Git-Tools-Submodules)
+- [CMake doc](https://cmake.org/documentation/)
 
 ## License
 


### PR DESCRIPTION
## Title
Improve CMatcher throughput with shallow conversion, key caching, and memory-pool reset

## Motivation
- Boost CMatcher performance on complex queries without changing the public Ruby API.
- After changes, performance is effectively on par with plain Ruby for the tested workload.

## Benchmark
- Complex query (Mongory) use CMatcher (100000 records)

Before:
```
0.036906  0.000000  0.036906 (0.036921)
0.036334  0.000011  0.036345 (0.036359)
0.034835  0.000000  0.034835 (0.034849)
0.034577  0.000000  0.034577 (0.034643)
0.034615  0.000003  0.034618 (0.034633)
```

After:
```
0.014865  0.000000  0.014865 (0.014865)
0.013389  0.000974  0.014363 (0.014365)
0.014450  0.000016  0.014466 (0.014466)
0.014496  0.000000  0.014496 (0.014496)
0.014616  0.000005  0.014621 (0.014621)
```

- Result: ~2.4x speedup; effectively equal to plain Ruby performance in this scenario.

## Key Changes
- **Dual memory pools with reset**
  - Introduce `ruby_mongory_memory_pool_t` (keeps `owner`).
  - Add per-matcher `scratch_pool` for per-call allocations; use `pool->reset` after `match`/`explain` to avoid frequent alloc/free.
  - Update submodule `mongory-core` to a commit that adds `pool->reset`.

- **Shallow conversion and lazy containers**
  - Split conversion into `ruby_to_mongory_value_primitive`, `ruby_to_mongory_value_shallow`, `ruby_to_mongory_value_deep`.
  - New wrappers:
    - `ruby_mongory_table_t`: lazy `Hash` lookup via custom `get`.
    - `ruby_mongory_array_t`: lazy `Array` access via `get`/`each`.
  - Preserve `value->origin = rb_value` for GC reachability and introspection.

- **Key caching to reduce Ruby object churn**
  - Per-matcher `string_map` and `symbol_map` cache for keys.
  - `cache_fetch_string`/`cache_fetch_symbol` reuse Ruby `String`/`Symbol` objects to minimize allocations and interning overhead.

- **GC integration**
  - Add `ruby_mongory_matcher_mark` and set `.dmark` in `rb_data_type_t` to mark cached objects and any `value->origin`.
  - Ensures cached keys and lazily-wrapped values are kept alive correctly.

- **Call-site improvements**
  - `CMatcher#match` and `CMatcher#explain` now use `scratch_pool` and call `reset`—no per-call pool allocation/free.

- **Misc**
  - Export `mongory_value_to_ruby`.
  - Remove `<time.h>`, add `<string.h>`.
  - Minor English wording cleanups in `SUBMODULE_INTEGRATION.md`.

## Submodule Update
- `ext/mongory_ext/mongory-core`: a8b4511 → 4348c4d
  - feat(memory pool): add `pool->reset` API
  - refactor: matcher naming cleanup

## Impact
- No public Ruby API changes.
- Significant CPU and allocation reduction in complex query paths.
- Lower GC pressure due to key caching and shallow conversion.

## Risks and Considerations
- Ensure GC marking covers all cached `String`/`Symbol` and any `value->origin` references.
- Thread safety: caches are per-matcher; no global state introduced.
- Behavior parity: lazy access must mirror previous deep conversion semantics for arrays/hashes.

## Testing and Verification
- Full test suite passed.
- Benchmarks run and recorded above.
- Manual verification of `match`/`explain` paths with nested arrays/hashes.

## Reviewer Notes
- Focus on:
  - Correctness of `ruby_mongory_matcher_mark` and `origin` usage.
  - `table.get` semantics (string-first, symbol fallback) matching expected Ruby behavior.
  - Proper use of `scratch_pool->reset` and no hidden lifetime issues.

- Out of scope:
  - Public API changes (none introduced).
  - Altering user-facing matcher DSL.

- Follow-ups:
  - Consider optional stats counters for cache hit/miss in debug builds.
  - Explore similar shallow/lazy patterns in other hot paths if any.

- Checklist:
  - Submodule bump included.
  - Build with core ok.
  - Specs and benchmarks executed.

- Thanks for reviewing!